### PR TITLE
imp: minor cleanups + more infos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,56 @@
 # evmos-perf
 
+This repository contains a testing setup to inspect and compare key metrics of Evmos versions. At the moment, two Evmos nodes are started and automated bots will send transactions to both nodes.
+[Prometheus](https://prometheus.io/docs/introduction/overview/) is used to create timeseries of the recorded data, while we are using [Grafana](https://grafana.com/docs/) to create interactive dashboards for inspection.
 
-### Run
+## Run
+
+To run the testing setup, start the docker containers (defined in [docker-compose.yml](https://github.com/evmos/testing/blob/main/docker-compose.yml)) using
 
 ```bash
 docker-compose up -d
 ```
 
+This will run the containers in the background. If you want to see all logs immediately, omit the `-d` flag. To inspect all logs, run
+
 ```bash
 docker-compose logs -f
 ```
+
+To get the log outputs for individual services (e.g. the individual Evmos nodes), you can specify the service to be printed to the terminal output by adding this as an argument to the `docker compose logs` command, e.g.
 
 ```bash
 docker-compose logs evmos-devnet1 -f
 ```
 
+or
+
 ```bash
 docker-compose logs tx-bot1 -f
 ```
 
-To stop:
+If you want to stop the execution of the testing setup, use
 
 ```bash
 docker-compose down --volumes
 ```
 
-### Customize
+The `--volumes` flag specifies to [remove all named volumes](https://docs.docker.com/engine/reference/commandline/compose_down), which are defined in the [`volumes` section](https://github.com/evmos/testing/blob/main/docker-compose.yml#L3) in the docker-compose configuration file. 
+
+## Customize
 
 You can update the commits to be tested by updating `commit_hash` for `evmos-devnet1` and `evmos-devnet2` in `docker-compose.yml`.
 
 To add more flags to evmosd start command, you can use `extra_flags` in build args of evmos devnet. For example, to add `--metrics`, you can use `extra_flags=--metrics`
 
-### Output
+## Output
 
-Grafana: http://localhost:8000, username: admin, password: admin
+To access the created Grafana dashboards, go to http://localhost:8000 while `docker compose` is running.
 
-Devnet1 tendermint metrics: http://localhost:26660/metrics
+- Username: `admin`
+- Password: `admin`
 
-Devnet2 tendermint metrics: http://localhost:26661/metrics
+In-depth Tendermint metrics are hosted at
+
+- devnet1: http://localhost:26660/metrics
+- devnet2: http://localhost:26661/metrics

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # evmos-perf
 
-This repository contains a testing setup to inspect and compare key metrics of Evmos versions. At the moment, two Evmos nodes are started and automated bots will send transactions to both nodes.
+This repository contains a testing setup to inspect and compare key metrics of Evmos versions. At the moment, two Evmos nodes are started and [automated bots](https://github.com/facs95/tx-bot) will send transactions to both nodes.
 [Prometheus](https://prometheus.io/docs/introduction/overview/) is used to create timeseries of the recorded data, while we are using [Grafana](https://grafana.com/docs/) to create interactive dashboards for inspection.
 
 ## Run

--- a/evmos-devnet/start.sh
+++ b/evmos-devnet/start.sh
@@ -26,13 +26,13 @@ echo "prepare genesis: Sign genesis transaction"
 ./evmosd gentx $KEY 1000000000000000000stake --keyring-backend test --home $DATA_DIR --keyring-backend test --chain-id $CHAINID
 echo "prepare genesis: Collect genesis tx"
 ./evmosd collect-gentxs --home $DATA_DIR
-sed -i 's/aphoton/aevmos/g' $DATA_DIR/config/genesis.json
+sed -i 's/aphoton/aevmos/g' $GENESIS
 
 echo "prepare genesis: Run validate-genesis to ensure everything worked and that the genesis file is setup correctly"
 ./evmosd validate-genesis --home $DATA_DIR
 
-sed -i 's/prometheus = false/prometheus = true/g' $DATA_DIR/config/config.toml
-sed -i 's/pprof_laddr = "localhost:6060"/pprof_laddr = "0.0.0.0:6060"/g' $DATA_DIR/config/config.toml
+sed -i 's/prometheus = false/prometheus = true/g' $CONFIG
+sed -i 's/pprof_laddr = "localhost:6060"/pprof_laddr = "0.0.0.0:6060"/g' $CONFIG
 # Change to 1s to have the same default configuration as v9
 sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' "$CONFIG"
 
@@ -44,4 +44,4 @@ echo "starting evmos node $i in background ..."
 --keyring-backend test --home $DATA_DIR \
 >$DATA_DIR/node.log $EXTRA_FLAGS
 
-# curl localhost:8545 -X POST -H "Content-Type: application/json" --data '{"method":"eth_getBalance","params":["0x1cF80B60F4F58221AaFFDBb2e513C0Ef1F809494", "latest"],"id":1,"jsonrpc":"2.0"}
+# curl localhost:8545 -X POST -H "Content-Type: application/json" --data '{"method":"eth_getBalance","params":["0x1cF80B60F4F58221AaFFDBb2e513C0Ef1F809494", "latest"],"id":1,"jsonrpc":"2.0"}'

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -9,43 +9,36 @@ global:
 scrape_configs:
 
   - job_name: 'prometheus'
-    scrape_interval: 1s
     static_configs:
       - targets: ["localhost:9090"]
 
   - job_name: "cadvisor"
-    scrape_interval: 1s
     static_configs:
       - targets: ["cadvisor:8080"]
 
   - job_name: "evmos-tendermint1"
-    scrape_interval: 1s
     static_configs:
       - targets: ["evmos-devnet1:26660"]
 
   - job_name: "evmos-rpc1"
-    scrape_interval: 1s
     metrics_path: /debug/metrics/prometheus
     static_configs:
       - targets: ["evmos-devnet1:6065"]
 
   - job_name: "evmos-tendermint2"
-    scrape_interval: 1s
     static_configs:
       - targets: ["evmos-devnet2:26660"]
 
   - job_name: "evmos-rpc2"
-    scrape_interval: 1s
     metrics_path: /debug/metrics/prometheus
     static_configs:
       - targets: ["evmos-devnet2:6065"]
 
   - job_name: "tx-bot1"
-    scrape_interval: 1s
     static_configs:
       - targets: ["tx-bot1:8080"]
 
   - job_name: "tx-bot2"
-    scrape_interval: 1s
     static_configs:
       - targets: ["tx-bot2:8080"]
+


### PR DESCRIPTION
I've removed the unnecessary overwriting of `scrape_interval` for the Prometheus jobs and added more information to the README for people who were previously not familiar with this setup (like me).