### PR TITLE
chore(fix) change chain id to be 9000

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ localnet-start: localnet-clean
 	fi; \
 	echo "Starting multi-node setup with $$REPO ..."; \
 	bin="$$REPO"d; \
-	chainID="$$REPO"_9999-1; \
+	chainID="$$REPO"_9000-1; \
 	mkdir localnet/build; \
 	docker run --rm -v $(CURDIR)/localnet/build:/$$REPO:Z localnet/node "./"$$bin" testnet init-files --v 4 -o /"$$REPO" --keyring-backend=test --starting-ip-address 192.167.10.2 --chain-id "$$chainID""; \
 	CHAIN=$$REPO localnet/setup_genesis.sh; \

--- a/grafana/provisioning/localnet/dashboards/node-full-dashboard.json
+++ b/grafana/provisioning/localnet/dashboards/node-full-dashboard.json
@@ -1146,8 +1146,8 @@
       {
         "current": {
           "selected": false,
-          "text": "evmos_9999-1",
-          "value": "evmos_9999-1"
+          "text": "evmos_9000-1",
+          "value": "evmos_9000-1"
         },
         "datasource": {
           "type": "prometheus",

--- a/localnet/setup_genesis.sh
+++ b/localnet/setup_genesis.sh
@@ -7,7 +7,7 @@ if [[ -z "${CHAIN}" ]]; then CHAIN="evmos"; fi
 if [[ $CHAIN == "evmos" ]]; then DENOM="aevmos"; fi
 if [[ $CHAIN == "ethermint" ]]; then DENOM="aphoton"; fi
 
-CHAINID="$CHAIN"_9999-1
+CHAINID="$CHAIN"_9000-1
 CHAIND="$CHAIN"d
 MONIKER="orchestrator"
 


### PR DESCRIPTION
With the latest changes on the repo, the Evmos codebase can only receive tx from the corresponding chain ids (9000 or 9001).

This PR introduces the changes to avoid having issues with this new feature