### PR TITLE
fix: bump metrics to cometbft endpoints

### DIFF
--- a/grafana/provisioning/dashboards/cosmos-dashboard.json
+++ b/grafana/provisioning/dashboards/cosmos-dashboard.json
@@ -150,7 +150,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_consensus_height{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_consensus_height{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "hide": false,
             "instant": true,
@@ -221,7 +221,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_consensus_total_txs{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_consensus_total_txs{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "interval": "30s",
             "intervalFactor": 1,
@@ -300,7 +300,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "avg(rate(tendermint_consensus_block_interval_seconds_sum{chain_id=\"$chain_id\", instance=\"$instance\"}[1m])/rate(tendermint_consensus_block_interval_seconds_count{chain_id=\"$chain_id\", instance=\"$instance\"}[1m]))",
+            "expr": "avg(rate(cometbft_consensus_block_interval_seconds_sum{chain_id=\"$chain_id\", instance=\"$instance\"}[1m])/rate(cometbft_consensus_block_interval_seconds_count{chain_id=\"$chain_id\", instance=\"$instance\"}[1m]))",
             "format": "time_series",
             "interval": "30s",
             "intervalFactor": 1,
@@ -370,7 +370,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_consensus_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_consensus_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "instant": false,
             "interval": "30s",
@@ -443,7 +443,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_consensus_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_consensus_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "instant": false,
             "interval": "",
@@ -455,7 +455,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_consensus_missing_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_consensus_missing_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -466,7 +466,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_consensus_byzantine_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_consensus_byzantine_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Byzantine",
@@ -567,7 +567,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_consensus_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_consensus_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "instant": false,
             "interval": "",
@@ -579,7 +579,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_consensus_missing_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_consensus_missing_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -590,7 +590,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_consensus_byzantine_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_consensus_byzantine_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "Byzantine",
@@ -690,7 +690,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_consensus_block_size_bytes{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_consensus_block_size_bytes{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "instant": false,
             "interval": "",
@@ -793,7 +793,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_consensus_num_txs{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_consensus_num_txs{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "instant": false,
             "interval": "",
@@ -924,7 +924,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_p2p_peers{chain_id=\"$chain_id\", instance=~\"$instance\"}",
+            "expr": "cometbft_p2p_peers{chain_id=\"$chain_id\", instance=~\"$instance\"}",
             "format": "time_series",
             "instant": true,
             "interval": "30s",
@@ -996,7 +996,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_mempool_size{chain_id=\"$chain_id\", instance=~\"$instance\"}",
+            "expr": "cometbft_mempool_size{chain_id=\"$chain_id\", instance=~\"$instance\"}",
             "format": "time_series",
             "instant": true,
             "interval": "30s",
@@ -1066,7 +1066,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_mempool_failed_txs{chain_id=\"$chain_id\", instance=~\"$instance\"}",
+            "expr": "cometbft_mempool_failed_txs{chain_id=\"$chain_id\", instance=~\"$instance\"}",
             "format": "time_series",
             "instant": true,
             "interval": "30s",
@@ -1136,7 +1136,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_mempool_recheck_times{chain_id=\"$chain_id\", instance=~\"$instance\"}",
+            "expr": "cometbft_mempool_recheck_times{chain_id=\"$chain_id\", instance=~\"$instance\"}",
             "format": "time_series",
             "instant": true,
             "interval": "30s",
@@ -1202,7 +1202,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_p2p_peer_receive_bytes_total{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_p2p_peer_receive_bytes_total{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "{{peer_id}}",
@@ -1296,7 +1296,7 @@
             "datasource": {
               "uid": "$DS"
             },
-            "expr": "tendermint_p2p_peer_send_bytes_total{chain_id=\"$chain_id\", instance=\"$instance\"}",
+            "expr": "cometbft_p2p_peer_send_bytes_total{chain_id=\"$chain_id\", instance=\"$instance\"}",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "{{peer_id}}",
@@ -1372,7 +1372,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "definition": "label_values(tendermint_consensus_height, chain_id)",
+          "definition": "label_values(cometbft_consensus_height, chain_id)",
           "hide": 0,
           "includeAll": false,
           "label": "Chain ID",
@@ -1380,7 +1380,7 @@
           "name": "chain_id",
           "options": [],
           "query": {
-            "query": "label_values(tendermint_consensus_height, chain_id)",
+            "query": "label_values(cometbft_consensus_height, chain_id)",
             "refId": "Prometheus-chain_id-Variable-Query"
           },
           "refresh": 1,
@@ -1402,7 +1402,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "definition": "label_values(tendermint_consensus_height{chain_id=\"$chain_id\"}, instance)",
+          "definition": "label_values(cometbft_consensus_height{chain_id=\"$chain_id\"}, instance)",
           "hide": 0,
           "includeAll": false,
           "label": "Instance",
@@ -1410,7 +1410,7 @@
           "name": "instance",
           "options": [],
           "query": {
-            "query": "label_values(tendermint_consensus_height{chain_id=\"$chain_id\"}, instance)",
+            "query": "label_values(cometbft_consensus_height{chain_id=\"$chain_id\"}, instance)",
             "refId": "Prometheus-instance-Variable-Query"
           },
           "refresh": 1,

--- a/grafana/provisioning/dashboards/node-full-dashboard.json
+++ b/grafana/provisioning/dashboards/node-full-dashboard.json
@@ -115,7 +115,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "tendermint_consensus_height{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_height{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -186,7 +186,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_total_txs{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_total_txs{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "interval": "30s",
           "intervalFactor": 1,
@@ -265,7 +265,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(tendermint_consensus_block_interval_seconds_sum{chain_id=\"$chain_id\", job=\"$job\"}[1m])/rate(tendermint_consensus_block_interval_seconds_count{chain_id=\"$chain_id\", job=\"$job\"}[1m]))",
+          "expr": "avg(rate(cometbft_consensus_block_interval_seconds_sum{chain_id=\"$chain_id\", job=\"$job\"}[1m])/rate(cometbft_consensus_block_interval_seconds_count{chain_id=\"$chain_id\", job=\"$job\"}[1m]))",
           "format": "time_series",
           "interval": "30s",
           "intervalFactor": 1,
@@ -345,7 +345,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(tendermint_consensus_missing_validators{chain_id=\"$chain_id\", job=\"$job\"})",
+          "expr": "max(cometbft_consensus_missing_validators{chain_id=\"$chain_id\", job=\"$job\"})",
           "format": "time_series",
           "interval": "30s",
           "intervalFactor": 1,
@@ -415,7 +415,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "instant": false,
           "interval": "30s",
@@ -490,7 +490,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_validators{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_validators{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -503,7 +503,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_missing_validators{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_missing_validators{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -515,7 +515,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_byzantine_validators{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_byzantine_validators{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Byzantine",
@@ -618,7 +618,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -631,7 +631,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_missing_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_missing_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -643,7 +643,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_byzantine_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_byzantine_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Byzantine",
@@ -745,7 +745,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_block_size_bytes{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_block_size_bytes{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -850,7 +850,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_num_txs{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_num_txs{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -941,7 +941,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_mempool_size{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_mempool_size{chain_id=\"$chain_id\", job=\"$job\"}",
           "interval": "",
           "legendFormat": "Mempool Size",
           "refId": "A"
@@ -986,7 +986,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "tendermint_consensus_rounds",
+      "description": "cometbft_consensus_rounds",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1027,7 +1027,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_rounds{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_rounds{chain_id=\"$chain_id\", job=\"$job\"}",
           "interval": "",
           "legendFormat": "Round",
           "refId": "A"
@@ -1128,7 +1128,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "label_values(tendermint_consensus_height{job=\"$job\"}, chain_id)",
+        "definition": "label_values(cometbft_consensus_height{job=\"$job\"}, chain_id)",
         "hide": 0,
         "includeAll": false,
         "label": "ChainID",
@@ -1136,7 +1136,7 @@
         "name": "chain_id",
         "options": [],
         "query": {
-          "query": "label_values(tendermint_consensus_height{job=\"$job\"}, chain_id)",
+          "query": "label_values(cometbft_consensus_height{job=\"$job\"}, chain_id)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/grafana/provisioning/localnet/dashboards/cosmos-dashboard.json
+++ b/grafana/provisioning/localnet/dashboards/cosmos-dashboard.json
@@ -148,7 +148,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_height{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_height{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -217,7 +217,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_total_txs{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_total_txs{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "interval": "30s",
           "intervalFactor": 1,
@@ -294,7 +294,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_block_interval_seconds{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_block_interval_seconds{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "interval": "30s",
           "intervalFactor": 1,
@@ -362,7 +362,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "instant": false,
           "interval": "30s",
@@ -435,7 +435,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -447,7 +447,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_missing_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_missing_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -458,7 +458,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_byzantine_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_byzantine_validators{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Byzantine",
@@ -559,7 +559,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -571,7 +571,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_missing_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_missing_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -582,7 +582,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_byzantine_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_byzantine_validators_power{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Byzantine",
@@ -682,7 +682,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_block_size_bytes{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_block_size_bytes{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -785,7 +785,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_consensus_num_txs{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_consensus_num_txs{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -914,7 +914,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_p2p_peers{chain_id=\"$chain_id\", instance=~\"$instance\"}",
+          "expr": "cometbft_p2p_peers{chain_id=\"$chain_id\", instance=~\"$instance\"}",
           "format": "time_series",
           "instant": true,
           "interval": "30s",
@@ -984,7 +984,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_mempool_size{chain_id=\"$chain_id\", instance=~\"$instance\"}",
+          "expr": "cometbft_mempool_size{chain_id=\"$chain_id\", instance=~\"$instance\"}",
           "format": "time_series",
           "instant": true,
           "interval": "30s",
@@ -1052,7 +1052,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_mempool_failed_txs{chain_id=\"$chain_id\", instance=~\"$instance\"}",
+          "expr": "cometbft_mempool_failed_txs{chain_id=\"$chain_id\", instance=~\"$instance\"}",
           "format": "time_series",
           "instant": true,
           "interval": "30s",
@@ -1120,7 +1120,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_mempool_recheck_times{chain_id=\"$chain_id\", instance=~\"$instance\"}",
+          "expr": "cometbft_mempool_recheck_times{chain_id=\"$chain_id\", instance=~\"$instance\"}",
           "format": "time_series",
           "instant": true,
           "interval": "30s",
@@ -1186,7 +1186,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_p2p_peer_receive_bytes_total{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_p2p_peer_receive_bytes_total{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1278,7 +1278,7 @@
           "datasource": {
             "uid": "$DS"
           },
-          "expr": "tendermint_p2p_peer_send_bytes_total{chain_id=\"$chain_id\", instance=\"$instance\"}",
+          "expr": "cometbft_p2p_peer_send_bytes_total{chain_id=\"$chain_id\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",
@@ -1349,7 +1349,7 @@
         "datasource": {
           "uid": "$DS"
         },
-        "definition": "label_values(tendermint_consensus_height, chain_id)",
+        "definition": "label_values(cometbft_consensus_height, chain_id)",
         "hide": 0,
         "includeAll": false,
         "label": "Chain ID",
@@ -1357,7 +1357,7 @@
         "name": "chain_id",
         "options": [],
         "query": {
-          "query": "label_values(tendermint_consensus_height, chain_id)",
+          "query": "label_values(cometbft_consensus_height, chain_id)",
           "refId": "Prometheus-chain_id-Variable-Query"
         },
         "refresh": 1,
@@ -1379,7 +1379,7 @@
         "datasource": {
           "uid": "$DS"
         },
-        "definition": "label_values(tendermint_consensus_height{chain_id=\"$chain_id\"}, instance)",
+        "definition": "label_values(cometbft_consensus_height{chain_id=\"$chain_id\"}, instance)",
         "hide": 0,
         "includeAll": false,
         "label": "Instance",
@@ -1387,7 +1387,7 @@
         "name": "instance",
         "options": [],
         "query": {
-          "query": "label_values(tendermint_consensus_height{chain_id=\"$chain_id\"}, instance)",
+          "query": "label_values(cometbft_consensus_height{chain_id=\"$chain_id\"}, instance)",
           "refId": "Prometheus-instance-Variable-Query"
         },
         "refresh": 1,

--- a/grafana/provisioning/localnet/dashboards/node-full-dashboard.json
+++ b/grafana/provisioning/localnet/dashboards/node-full-dashboard.json
@@ -117,7 +117,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "tendermint_consensus_height{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_height{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -190,7 +190,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_total_txs{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_total_txs{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "interval": "30s",
           "intervalFactor": 1,
@@ -271,7 +271,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "avg(rate(tendermint_consensus_block_interval_seconds_sum{chain_id=\"$chain_id\", job=\"$job\"}[1m])/rate(tendermint_consensus_block_interval_seconds_count{chain_id=\"$chain_id\", job=\"$job\"}[1m]))",
+          "expr": "avg(rate(cometbft_consensus_block_interval_seconds_sum{chain_id=\"$chain_id\", job=\"$job\"}[1m])/rate(cometbft_consensus_block_interval_seconds_count{chain_id=\"$chain_id\", job=\"$job\"}[1m]))",
           "format": "time_series",
           "interval": "30s",
           "intervalFactor": 1,
@@ -353,7 +353,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "max(tendermint_consensus_missing_validators{chain_id=\"$chain_id\", job=\"$job\"})",
+          "expr": "max(cometbft_consensus_missing_validators{chain_id=\"$chain_id\", job=\"$job\"})",
           "format": "time_series",
           "interval": "30s",
           "intervalFactor": 1,
@@ -425,7 +425,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "instant": false,
           "interval": "30s",
@@ -500,7 +500,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_validators{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_validators{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -513,7 +513,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_missing_validators{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_missing_validators{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -525,7 +525,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_byzantine_validators{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_byzantine_validators{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Byzantine",
@@ -628,7 +628,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -641,7 +641,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_missing_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_missing_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -653,7 +653,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_byzantine_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_byzantine_validators_power{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Byzantine",
@@ -755,7 +755,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_block_size_bytes{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_block_size_bytes{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -860,7 +860,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_num_txs{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_num_txs{chain_id=\"$chain_id\", job=\"$job\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -951,7 +951,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_mempool_size{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_mempool_size{chain_id=\"$chain_id\", job=\"$job\"}",
           "interval": "",
           "legendFormat": "Mempool Size",
           "refId": "A"
@@ -996,7 +996,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "tendermint_consensus_rounds",
+      "description": "cometbft_consensus_rounds",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1037,7 +1037,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "expr": "tendermint_consensus_rounds{chain_id=\"$chain_id\", job=\"$job\"}",
+          "expr": "cometbft_consensus_rounds{chain_id=\"$chain_id\", job=\"$job\"}",
           "interval": "",
           "legendFormat": "Round",
           "refId": "A"
@@ -1153,7 +1153,7 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "label_values(tendermint_consensus_height{job=\"$job\"}, chain_id)",
+        "definition": "label_values(cometbft_consensus_height{job=\"$job\"}, chain_id)",
         "hide": 0,
         "includeAll": false,
         "label": "ChainID",
@@ -1161,7 +1161,7 @@
         "name": "chain_id",
         "options": [],
         "query": {
-          "query": "label_values(tendermint_consensus_height{job=\"$job\"}, chain_id)",
+          "query": "label_values(cometbft_consensus_height{job=\"$job\"}, chain_id)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
Update metrics to use cometbfts endpoints instead of tendermint.

NOTE: This will only work on the latest versions